### PR TITLE
Dev backend eslint (don't merge until unanimous approval)

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -1,0 +1,69 @@
+"use strict";
+
+module.exports = {
+  root: true,
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: "script"
+  },
+  env: {
+    es6: true,
+    node: true
+  },
+  plugins: ["import", "promise"],
+  extends: [
+    "eslint:recommended",
+    "plugin:promise/recommended",
+    "plugin:import/recommended"
+  ],
+  rules: {
+    "no-console": "off",
+
+    "class-methods-use-this": "warn",
+    "no-extend-native": "warn",
+    "no-self-compare": "warn",
+    "no-throw-literal": "warn",
+    "prefer-promise-reject-errors": "warn",
+    "require-await": "warn",
+    "global-require": "warn",
+    "handle-callback-err": "warn",
+    "no-mixed-requires": "warn",
+    "no-path-concat": "warn",
+    "consistent-this": "warn",
+    "max-depth": "warn",
+    "max-nested-callbacks": "warn",
+    "no-lonely-if": "warn",
+    "no-unneeded-ternary": "warn",
+    "no-duplicate-imports": "warn",
+    "no-useless-computed-key": "warn",
+    "no-useless-constructor": "warn",
+    "no-useless-rename": "warn",
+    "symbol-description": "warn",
+
+    "no-template-curly-in-string": "error",
+    "accessor-pairs": "error",
+    "array-callback-return": "error",
+    "eqeqeq": "error",
+    "no-eval": "error",
+    "no-implied-eval": "error",
+    "no-invalid-this": "error",
+    "no-new-wrappers": "error",
+    "no-sequences": "error",
+    "no-unmodified-loop-condition": "error",
+    "no-unused-expressions": "error",
+    "no-void": "error",
+    "no-with": "error",
+    "radix": "error",
+    "strict": "error",
+    "no-label-var": "error",
+    "no-new-require": "error",
+    "no-sync": "error",
+    "camelcase": "error",
+    "no-confusing-error": "error",
+    "no-var": "error",
+    "prefer-const": "error",
+    "prefer-numeric-literals": "error",
+    "prefer-rest-params": "error",
+    "prefer-spread": "error"
+  }
+};

--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -60,7 +60,7 @@ module.exports = {
     "no-new-require": "error",
     "no-sync": "error",
     "camelcase": "error",
-    "no-confusing-error": "error",
+    "no-confusing-arrow": "error",
     "no-var": "error",
     "prefer-const": "error",
     "prefer-numeric-literals": "error",

--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -39,6 +39,7 @@ module.exports = {
     "no-useless-constructor": "warn",
     "no-useless-rename": "warn",
     "symbol-description": "warn",
+    "promise/no-return-in-finally": "warn",
 
     "no-template-curly-in-string": "error",
     "accessor-pairs": "error",
@@ -64,6 +65,8 @@ module.exports = {
     "prefer-const": "error",
     "prefer-numeric-literals": "error",
     "prefer-rest-params": "error",
-    "prefer-spread": "error"
+    "prefer-spread": "error",
+    "promise/valid-params": "error",
+    "import/no-extraneous-dependencies": "error"
   }
 };

--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -40,11 +40,12 @@ module.exports = {
     "no-useless-rename": "warn",
     "symbol-description": "warn",
     "promise/no-return-in-finally": "warn",
+    "promise/always-return": "warn",
 
     "no-template-curly-in-string": "error",
     "accessor-pairs": "error",
     "array-callback-return": "error",
-    "eqeqeq": "error",
+    eqeqeq: "error",
     "no-eval": "error",
     "no-implied-eval": "error",
     "no-invalid-this": "error",
@@ -54,19 +55,27 @@ module.exports = {
     "no-unused-expressions": "error",
     "no-void": "error",
     "no-with": "error",
-    "radix": "error",
-    "strict": "error",
+    radix: "error",
+    strict: "error",
     "no-label-var": "error",
     "no-new-require": "error",
     "no-sync": "error",
-    "camelcase": "error",
+    camelcase: "error",
     "no-confusing-arrow": "error",
     "no-var": "error",
     "prefer-const": "error",
     "prefer-numeric-literals": "error",
     "prefer-rest-params": "error",
     "prefer-spread": "error",
+    "no-unused-vars": ["error", { args: "none" }],
     "promise/valid-params": "error",
     "import/no-extraneous-dependencies": "error"
-  }
+  },
+  overrides: [
+    {
+      files: "**/*.test.js",
+      env: { jest: true },
+      rules: { "no-console": "error" }
+    }
+  ]
 };

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,31 +1,32 @@
-const express = require('express');
-const path = require('path');
+"use strict";
+
+const express = require("express");
 //const favicon = require('serve-favicon');
 
-const config = require('./config');
-const user = require('./controllers/user');
+const config = require("./config");
+const user = require("./controllers/user");
 
 // logging
-const logger = require('morgan');
-const log4js = require('log4js').getLogger();
-if (config.serverConfig.env === 'development') {
-  log4js.level = 'debug';
+const logger = require("morgan");
+const log4js = require("log4js").getLogger();
+if (config.serverConfig.env === "development") {
+  log4js.level = "debug";
 }
 
 const app = express();
 
 // set server config
-app.set('serverConfig', config.serverConfig);
+app.set("serverConfig", config.serverConfig);
 // set authentication config
-app.set('authConfig', config.authConfig);
+app.set("authConfig", config.authConfig);
 // set database config
-app.set('databaseConfig', config.databaseConfig);
+app.set("databaseConfig", config.databaseConfig);
 
 // uncomment after placing your favicon in /public
 //app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
-app.use(logger('dev'));
+app.use(logger("dev"));
 app.use(express.urlencoded({ extended: false }));
-app.use(express.json())
+app.use(express.json());
 
 app.use(function(req, res, next) {
   res.header("Access-Control-Allow-Origin", "*");
@@ -36,40 +37,39 @@ app.use(function(req, res, next) {
   next();
 });
 
-app.use('/user', user);
+app.use("/user", user);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {
-  const err = new Error('Not Found');
+  const err = new Error("Not Found");
   err.status = 404;
   next(err);
 });
 
 // error handler
 app.use(function(err, req, res, next) {
-    // set locals, only providing error in development
-    res.locals.message = err.message;
-    res.locals.error = req.app.get('serverConfig').env === 'development' ? err : {};
+  // set locals, only providing error in development
+  res.locals.message = err.message;
+  res.locals.error =
+    req.app.get("serverConfig").env === "development" ? err : {};
 
-    // send back error
-    err.status = err.status || 500;
+  // send back error
+  err.status = err.status || 500;
 
-    // don't leak error if not in development
-    if (req.app.get('serverConfig').env !== 'development' && err.status === 500) {
-        err.message = 'Internal Server Error';
-    } else {
-      if (err.status < 500) {
-        log4js.warn(err.message);
-      } else {
-        log4js.error(err);
-      }
-    }
-    res.status(err.status);
-    res.json({status: err.status, message: err.message});
+  // don't leak error if not in development
+  if (req.app.get("serverConfig").env !== "development" && err.status === 500) {
+    err.message = "Internal Server Error";
+  } else if (err.status < 500) {
+    log4js.warn(err.message);
+  } else {
+    log4js.error(err);
+  }
+  res.status(err.status);
+  res.json({ status: err.status, message: err.message });
 });
 
-if (app.get('env') === 'development') {
-    app.locals.pretty = true;
+if (app.get("env") === "development") {
+  app.locals.pretty = true;
 }
 
 module.exports = app;

--- a/backend/config.js
+++ b/backend/config.js
@@ -1,17 +1,19 @@
+"use strict";
+
 module.exports = {
-    serverConfig : {
-        "env" : 'development',
-        "port" : process.env.PORT || '8080'
-    },
-    authConfig : {
-        "authKey" : process.env.AUTH_EC_KEY || 'testsecret',
-        "expiresIn" : '15m'
-    },
-    databaseConfig: {
-        "host" : process.env.DB_HOST || 'localhost',
-    	"username" : process.env.DB_USERNAME, 
-    	"password" : process.env.DB_PASSWORD,
-        "port" : process.env.DB_PORT || '3306',
-        "schema" : process.env.DB_NAME || 'tournamentbuzz'
-    }
+  serverConfig: {
+    env: "development",
+    port: process.env.PORT || "8080"
+  },
+  authConfig: {
+    authKey: process.env.AUTH_EC_KEY || "testsecret",
+    expiresIn: "15m"
+  },
+  databaseConfig: {
+    host: process.env.DB_HOST || "localhost",
+    username: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    port: process.env.DB_PORT || "3306",
+    schema: process.env.DB_NAME || "tournamentbuzz"
+  }
 };

--- a/backend/controllers/user.js
+++ b/backend/controllers/user.js
@@ -1,14 +1,16 @@
-const express = require('express');
+"use strict";
+
+const express = require("express");
 const router = express.Router();
 
-const login = require('./user/login');
-const renew = require('./user/renew');
-const register = require('./user/register');
+const login = require("./user/login");
+const renew = require("./user/renew");
+const register = require("./user/register");
 
-const requireAuth = require('../middleware/auth/verify')
+const requireAuth = require("../middleware/auth/verify");
 
-router.use('/login', login);
-router.use('/renew', requireAuth, renew);
-router.use('/register', register);
+router.use("/login", login);
+router.use("/renew", requireAuth, renew);
+router.use("/register", register);
 
 module.exports = router;

--- a/backend/controllers/user/login.js
+++ b/backend/controllers/user/login.js
@@ -1,33 +1,45 @@
-const express = require('express');
-const jwt = require('jsonwebtoken');
-const sqlwrapper = require('../../model/wrapper');
-const connection = require('../../model/connect');
+"use strict";
+
+const express = require("express");
+const jwt = require("jsonwebtoken");
+const sqlwrapper = require("../../model/wrapper");
+const connection = require("../../model/connect");
 const router = express.Router();
 
-router.post('', function(req, res, next) {
-    if (!req.body || !req.body.email || !req.body.password) {
-        const err = new Error('Malformed Request');
-        err.status = 400;
+router.post("", function(req, res, next) {
+  if (!req.body || !req.body.email || !req.body.password) {
+    const err = new Error("Malformed Request");
+    err.status = 400;
+    next(err);
+    return;
+  }
+  const c = connection.connect(
+    req.app.get("databaseConfig").host,
+    req.app.get("databaseConfig").username,
+    req.app.get("databaseConfig").password,
+    req.app.get("databaseConfig").schema
+  );
+  sqlwrapper
+    .checkCredentials(c, req.body.email, req.body.password)
+    .then(function(validCredentials) {
+      if (validCredentials) {
+        const token = jwt.sign(
+          {
+            id: req.body.email
+          },
+          req.app.get("authConfig").authKey,
+          { expiresIn: req.app.get("authConfig").expiresIn }
+        );
+        res.status(200);
+        res.json({ jwt: token });
+      } else {
+        const err = new Error("Invalid Username or Password");
+        err.status = 401;
         next(err);
-        return;
-    }
-    const c = connection.connect(req.app.get('databaseConfig').host, 
-        req.app.get('databaseConfig').username, req.app.get('databaseConfig').password, req.app.get('databaseConfig').schema);
-    sqlwrapper.checkCredentials(c, req.body.email, req.body.password).then(function(validCredentials) {
-        if (validCredentials) {
-            const token = jwt.sign(
-                {
-                    id: req.body.email
-                }, req.app.get('authConfig').authKey, { expiresIn: req.app.get('authConfig').expiresIn });
-            res.status(200);
-            res.json({jwt: token});
-        } else {
-            const err = new Error('Invalid Username or Password');
-            err.status = 401;
-            next(err);
-        }
-    }).catch(function(err) {
-        next(err);
+      }
+    })
+    .catch(function(err) {
+      next(err);
     });
 });
 

--- a/backend/controllers/user/login.js
+++ b/backend/controllers/user/login.js
@@ -6,41 +6,43 @@ const sqlwrapper = require("../../model/wrapper");
 const connection = require("../../model/connect");
 const router = express.Router();
 
-router.post("", function(req, res, next) {
+router.post("", async (req, res, next) => {
   if (!req.body || !req.body.email || !req.body.password) {
     const err = new Error("Malformed Request");
     err.status = 400;
     next(err);
     return;
   }
-  const c = connection.connect(
-    req.app.get("databaseConfig").host,
-    req.app.get("databaseConfig").username,
-    req.app.get("databaseConfig").password,
-    req.app.get("databaseConfig").schema
-  );
-  sqlwrapper
-    .checkCredentials(c, req.body.email, req.body.password)
-    .then(function(validCredentials) {
-      if (validCredentials) {
-        const token = jwt.sign(
-          {
-            id: req.body.email
-          },
-          req.app.get("authConfig").authKey,
-          { expiresIn: req.app.get("authConfig").expiresIn }
-        );
-        res.status(200);
-        res.json({ jwt: token });
-      } else {
-        const err = new Error("Invalid Username or Password");
-        err.status = 401;
-        next(err);
-      }
-    })
-    .catch(function(err) {
+  try {
+    const c = connection.connect(
+      req.app.get("databaseConfig").host,
+      req.app.get("databaseConfig").username,
+      req.app.get("databaseConfig").password,
+      req.app.get("databaseConfig").schema
+    );
+    const validCredentials = await sqlwrapper.checkCredentials(
+      c,
+      req.body.email,
+      req.body.password
+    );
+    if (validCredentials) {
+      const token = jwt.sign(
+        {
+          id: req.body.email
+        },
+        req.app.get("authConfig").authKey,
+        { expiresIn: req.app.get("authConfig").expiresIn }
+      );
+      res.status(200);
+      res.json({ jwt: token });
+    } else {
+      const err = new Error("Invalid Username or Password");
+      err.status = 401;
       next(err);
-    });
+    }
+  } catch (err) {
+    next(err);
+  }
 });
 
 module.exports = router;

--- a/backend/controllers/user/login.test.js
+++ b/backend/controllers/user/login.test.js
@@ -1,178 +1,221 @@
-const request = require('supertest');
-const express = require('express');
-const mysql = require('mysql');
-const jwt = require('jsonwebtoken');
+"use strict";
 
-const config = require('../../config');
-const sqlwrapper = require('../../model/wrapper');
-const connection = require('../../model/connect');
-const login = require('./login');
+const request = require("supertest");
+const express = require("express");
+const mysql = require("mysql");
+const jwt = require("jsonwebtoken");
+
+const config = require("../../config");
+const sqlwrapper = require("../../model/wrapper");
+const connection = require("../../model/connect");
+const login = require("./login");
 
 const app = express();
 app.use(express.json());
 const databaseConfig = {
-    host: config.databaseConfig.host,
-    username: config.databaseConfig.username,
-    password: config.databaseConfig.password,
-    schema: 'temploginjestschema',
+  host: config.databaseConfig.host,
+  username: config.databaseConfig.username,
+  password: config.databaseConfig.password,
+  schema: "temploginjestschema"
 };
-const authConfig = {authKey: 'loginTestSecret', expiresIn: '1s'};
-app.set('authConfig', authConfig);
-app.set('serverConfig', config.serverConfig);
-app.set('databaseConfig', databaseConfig);
+const authConfig = { authKey: "loginTestSecret", expiresIn: "1s" };
+app.set("authConfig", authConfig);
+app.set("serverConfig", config.serverConfig);
+app.set("databaseConfig", databaseConfig);
 
 function mockErrorHandler(err, req, res, next) {
-    if (err) {
-        res.status(err.status);
-        res.json({status: err.status, message: err.message});
-    } else {
-        res.status(500);
-        res.json({status: 500, message: 'something unexpected happened'});
-    }
+  if (err) {
+    res.status(err.status);
+    res.json({ status: err.status, message: err.message });
+  } else {
+    res.status(500);
+    res.json({ status: 500, message: "something unexpected happened" });
+  }
 }
 
-app.use('/user/login', login);
+app.use("/user/login", login);
 app.use(mockErrorHandler);
 
 async function setupTemporarySchema(host, username, password, temporarySchema) {
-    const c = mysql.createConnection({
-        host: host,
-        user: username,
-        password: password,
-    });
-    c.connect();
-    const setupSchemaQuery = 'CREATE SCHEMA ' + temporarySchema + ';';
-    await sqlwrapper.executeSQL(c, setupSchemaQuery, []).catch(function(err) {
-        throw err;
-    });
-    c.destroy();
-    const specC = mysql.createConnection({
-        host: host,
-        user: username,
-        password: password,
-        database : temporarySchema
-    });
-    specC.connect();
-    const setupUsersTableQuery = 
-    `CREATE TABLE users (
+  const c = mysql.createConnection({
+    host: host,
+    user: username,
+    password: password
+  });
+  c.connect();
+  const setupSchemaQuery = "CREATE SCHEMA " + temporarySchema + ";";
+  await sqlwrapper.executeSQL(c, setupSchemaQuery, []).catch(function(err) {
+    throw err;
+  });
+  c.destroy();
+  const specC = mysql.createConnection({
+    host: host,
+    user: username,
+    password: password,
+    database: temporarySchema
+  });
+  specC.connect();
+  const setupUsersTableQuery = `CREATE TABLE users (
         email VARCHAR(255) NOT NULL UNIQUE CHECK(email REGEXP '^[A-Za-z0-9][A-Za-z0-9]*@[A-Za-z0-9][A-Za-z0-9]*\\.[A-Za-z0-9]*$'),
         password VARCHAR(255) NOT NULL CHECK(passw LIKE '%________%'),
         username VARCHAR(60),
-        admin BOOL DEFAULT FALSE NOT NULL, 
+        admin BOOL DEFAULT FALSE NOT NULL,
         PRIMARY KEY(email)
-    );`
-    await sqlwrapper.executeSQL(specC, setupUsersTableQuery, []).catch(function(err) {
-        throw err;
+    );`;
+  await sqlwrapper
+    .executeSQL(specC, setupUsersTableQuery, [])
+    .catch(function(err) {
+      throw err;
     });
-    specC.destroy();
+  specC.destroy();
 }
 
-async function cleanupTemporarySchema(host, username, password, temporarySchema) {
-    const c = mysql.createConnection({
-        host: host,
-        user: username,
-        password: password,
-    });
-    c.connect();
-    const setupSchemaQuery = 'DROP SCHEMA ' + temporarySchema + ';';
-    await sqlwrapper.executeSQL(c, setupSchemaQuery, []).catch(function(err) {
-        throw err;
-    });
-    c.destroy();
+async function cleanupTemporarySchema(
+  host,
+  username,
+  password,
+  temporarySchema
+) {
+  const c = mysql.createConnection({
+    host: host,
+    user: username,
+    password: password
+  });
+  c.connect();
+  const setupSchemaQuery = "DROP SCHEMA " + temporarySchema + ";";
+  await sqlwrapper.executeSQL(c, setupSchemaQuery, []).catch(function(err) {
+    throw err;
+  });
+  c.destroy();
 }
 
 describe("login", () => {
-    const testUserEmail = 'test@gatech.edu';
-    const testUserPassword = 'testpassword';
-    const testUserName = 'Test User';
-    const temporarySchema = 'temploginjestschema';
-    beforeAll(async done => {
-        await setupTemporarySchema(databaseConfig.host, databaseConfig.username, databaseConfig.password, temporarySchema)
-            .catch(function(err) {
-                throw new Error('Unable to create temporary schema: ' + err.message);
-            });
-        const c = connection.connect(databaseConfig.host,
-            databaseConfig.username, databaseConfig.password, temporarySchema);
-        await sqlwrapper.createUser(c, testUserName, testUserEmail, testUserPassword, 0).catch(function(err) {
-            throw new Error('Unable to create user: ' + err.message);
-        });
-        c.destroy();
-        done();
+  const testUserEmail = "test@gatech.edu";
+  const testUserPassword = "testpassword";
+  const testUserName = "Test User";
+  const temporarySchema = "temploginjestschema";
+  beforeAll(async done => {
+    await setupTemporarySchema(
+      databaseConfig.host,
+      databaseConfig.username,
+      databaseConfig.password,
+      temporarySchema
+    ).catch(function(err) {
+      throw new Error("Unable to create temporary schema: " + err.message);
     });
-    
-    afterAll(async done => {
-        await cleanupTemporarySchema(databaseConfig.host,
-            databaseConfig.username, databaseConfig.password, temporarySchema).catch(function(err) {
-                throw new Error('Unable to cleanup temporary schema: ' + err.message);
-            });
-        done();
-    });
-    
-    test("Login Success", async done => {
-        const loginObject = {
-            email: testUserEmail,
-            password: testUserPassword
-        };
-        await request(app)
-            .post('/user/login')
-            .send(loginObject)
-            .set('Content-Type', 'application/json')
-            .set('Accept', 'application/json')
-            .expect('Content-Type', /json/)
-            .expect(200)
-            .expect(function(res) {
-                try {
-                    const payload = jwt.verify(res.body.jwt, app.get('authConfig').authKey);
-                    if (payload.id !== testUserEmail) {
-                        throw new Error('Unexpected ID, expected ' + testUserEmail + ', got ' + payload.id + ' instead');
-                    }
-                } catch(e) {
-                    e.message = 'Returned JWT is not valid for some reason or another: ' + e.message;
-                    throw e;
-                }
-            });
-        done();
-    });
+    const c = connection.connect(
+      databaseConfig.host,
+      databaseConfig.username,
+      databaseConfig.password,
+      temporarySchema
+    );
+    await sqlwrapper
+      .createUser(c, testUserName, testUserEmail, testUserPassword, 0)
+      .catch(function(err) {
+        throw new Error("Unable to create user: " + err.message);
+      });
+    c.destroy();
+    done();
+  });
 
-    test("Login Fail Incorrect Password", async done => {
-        const loginObject = {
-            email: testUserEmail,
-            password: 'incorrect_password'
-        };
-        await request(app)
-            .post('/user/login')
-            .send(loginObject)
-            .set('Content-Type', 'application/json')
-            .set('Accept', 'application/json')
-            .expect('Content-Type', /json/)
-            .expect(401)
-            .expect(function(res) {
-                const expectedError = 'Invalid Username or Password';
-                if (res.body.message !== expectedError) {
-                    throw new Error('Expected error: ' + expectedError + ', received: ' + res.body.message);
-                }
-            });
-        done();
+  afterAll(async done => {
+    await cleanupTemporarySchema(
+      databaseConfig.host,
+      databaseConfig.username,
+      databaseConfig.password,
+      temporarySchema
+    ).catch(function(err) {
+      throw new Error("Unable to cleanup temporary schema: " + err.message);
     });
-    
-    test("Login Fail Incorrect Username", async done => {
-        const loginObject = {
-            email: 'thisUsernameDoesNotExist',
-            password: testUserPassword
-        };
-        await request(app)
-            .post('/user/login')
-            .send(loginObject)
-            .set('Content-Type', 'application/json')
-            .set('Accept', 'application/json')
-            .expect('Content-Type', /json/)
-            .expect(401)
-            .expect(function(res) {
-                const expectedError = 'Invalid Username or Password';
-                if (res.body.message !== expectedError) {
-                    throw new Error('Expected error: ' + expectedError + ', received: ' + res.body.message);
-                }
-            });
-        done();
-    });
+    done();
+  });
+
+  test("Login Success", async done => {
+    const loginObject = {
+      email: testUserEmail,
+      password: testUserPassword
+    };
+    await request(app)
+      .post("/user/login")
+      .send(loginObject)
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json")
+      .expect("Content-Type", /json/)
+      .expect(200)
+      .expect(function(res) {
+        try {
+          const payload = jwt.verify(
+            res.body.jwt,
+            app.get("authConfig").authKey
+          );
+          if (payload.id !== testUserEmail) {
+            throw new Error(
+              "Unexpected ID, expected " +
+                testUserEmail +
+                ", got " +
+                payload.id +
+                " instead"
+            );
+          }
+        } catch (e) {
+          e.message =
+            "Returned JWT is not valid for some reason or another: " +
+            e.message;
+          throw e;
+        }
+      });
+    done();
+  });
+
+  test("Login Fail Incorrect Password", async done => {
+    const loginObject = {
+      email: testUserEmail,
+      password: "incorrect_password"
+    };
+    await request(app)
+      .post("/user/login")
+      .send(loginObject)
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json")
+      .expect("Content-Type", /json/)
+      .expect(401)
+      .expect(function(res) {
+        const expectedError = "Invalid Username or Password";
+        if (res.body.message !== expectedError) {
+          throw new Error(
+            "Expected error: " +
+              expectedError +
+              ", received: " +
+              res.body.message
+          );
+        }
+      });
+    done();
+  });
+
+  test("Login Fail Incorrect Username", async done => {
+    const loginObject = {
+      email: "thisUsernameDoesNotExist",
+      password: testUserPassword
+    };
+    await request(app)
+      .post("/user/login")
+      .send(loginObject)
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json")
+      .expect("Content-Type", /json/)
+      .expect(401)
+      .expect(function(res) {
+        const expectedError = "Invalid Username or Password";
+        if (res.body.message !== expectedError) {
+          throw new Error(
+            "Expected error: " +
+              expectedError +
+              ", received: " +
+              res.body.message
+          );
+        }
+      });
+    done();
+  });
 });

--- a/backend/controllers/user/login.test.js
+++ b/backend/controllers/user/login.test.js
@@ -44,9 +44,7 @@ async function setupTemporarySchema(host, username, password, temporarySchema) {
   });
   c.connect();
   const setupSchemaQuery = "CREATE SCHEMA " + temporarySchema + ";";
-  await sqlwrapper.executeSQL(c, setupSchemaQuery, []).catch(function(err) {
-    throw err;
-  });
+  await sqlwrapper.executeSQL(c, setupSchemaQuery, []);
   c.destroy();
   const specC = mysql.createConnection({
     host: host,
@@ -62,11 +60,7 @@ async function setupTemporarySchema(host, username, password, temporarySchema) {
         admin BOOL DEFAULT FALSE NOT NULL,
         PRIMARY KEY(email)
     );`;
-  await sqlwrapper
-    .executeSQL(specC, setupUsersTableQuery, [])
-    .catch(function(err) {
-      throw err;
-    });
+  await sqlwrapper.executeSQL(specC, setupUsersTableQuery, []);
   specC.destroy();
 }
 
@@ -83,9 +77,7 @@ async function cleanupTemporarySchema(
   });
   c.connect();
   const setupSchemaQuery = "DROP SCHEMA " + temporarySchema + ";";
-  await sqlwrapper.executeSQL(c, setupSchemaQuery, []).catch(function(err) {
-    throw err;
-  });
+  await sqlwrapper.executeSQL(c, setupSchemaQuery, []);
   c.destroy();
 }
 
@@ -142,7 +134,7 @@ describe("login", () => {
       .set("Accept", "application/json")
       .expect("Content-Type", /json/)
       .expect(200)
-      .expect(function(res) {
+      .expect(res => {
         try {
           const payload = jwt.verify(
             res.body.jwt,
@@ -179,7 +171,7 @@ describe("login", () => {
       .set("Accept", "application/json")
       .expect("Content-Type", /json/)
       .expect(401)
-      .expect(function(res) {
+      .expect(res => {
         const expectedError = "Invalid Username or Password";
         if (res.body.message !== expectedError) {
           throw new Error(
@@ -205,7 +197,7 @@ describe("login", () => {
       .set("Accept", "application/json")
       .expect("Content-Type", /json/)
       .expect(401)
-      .expect(function(res) {
+      .expect(res => {
         const expectedError = "Invalid Username or Password";
         if (res.body.message !== expectedError) {
           throw new Error(

--- a/backend/controllers/user/register.js
+++ b/backend/controllers/user/register.js
@@ -1,36 +1,55 @@
-const express = require('express');
-const jwt = require('jsonwebtoken');
-const sqlwrapper = require('../../model/wrapper');
-const connection = require('../../model/connect');
+"use strict";
+
+const express = require("express");
+const jwt = require("jsonwebtoken");
+const sqlwrapper = require("../../model/wrapper");
+const connection = require("../../model/connect");
 const router = express.Router();
 
-router.post('', function(req, res, next) {
-    if (!req.body || !req.body.email || !req.body.password || !req.body.name) {
-        const err = new Error('Malformed Request');
-        err.status = 400;
-        next(err);
-        return;
-    }
-    const c = connection.connect(req.app.get('databaseConfig').host,
-        req.app.get('databaseConfig').username, req.app.get('databaseConfig').password, req.app.get('databaseConfig').schema);
-    sqlwrapper.userExists(c, req.body.email).then(function(userExists) {
-    	if (userExists) {
-    		const err = new Error('User already exists!');
-    		err.status = 409;
-    		throw err;
-    	} else {
-    		return sqlwrapper.createUser(c, req.body.name, req.body.email, req.body.password, 0);
-    	}
-    }).then(function() {
-        const token = jwt.sign(
-            {
-                id: req.body.email
-            }, req.app.get('authConfig').authKey, { expiresIn: req.app.get('authConfig').expiresIn });
-        res.status(200);
-        res.json({jwt: token});
-	}).catch(function(err) {
-    	err.status = err.status || 500;
-    	next(err);
+router.post("", function(req, res, next) {
+  if (!req.body || !req.body.email || !req.body.password || !req.body.name) {
+    const err = new Error("Malformed Request");
+    err.status = 400;
+    next(err);
+    return;
+  }
+  const c = connection.connect(
+    req.app.get("databaseConfig").host,
+    req.app.get("databaseConfig").username,
+    req.app.get("databaseConfig").password,
+    req.app.get("databaseConfig").schema
+  );
+  sqlwrapper
+    .userExists(c, req.body.email)
+    .then(function(userExists) {
+      if (userExists) {
+        const err = new Error("User already exists!");
+        err.status = 409;
+        throw err;
+      } else {
+        return sqlwrapper.createUser(
+          c,
+          req.body.name,
+          req.body.email,
+          req.body.password,
+          0
+        );
+      }
+    })
+    .then(function() {
+      const token = jwt.sign(
+        {
+          id: req.body.email
+        },
+        req.app.get("authConfig").authKey,
+        { expiresIn: req.app.get("authConfig").expiresIn }
+      );
+      res.status(200);
+      res.json({ jwt: token });
+    })
+    .catch(function(err) {
+      err.status = err.status || 500;
+      next(err);
     });
 });
 

--- a/backend/controllers/user/register.js
+++ b/backend/controllers/user/register.js
@@ -6,51 +6,47 @@ const sqlwrapper = require("../../model/wrapper");
 const connection = require("../../model/connect");
 const router = express.Router();
 
-router.post("", function(req, res, next) {
+router.post("", async (req, res, next) => {
   if (!req.body || !req.body.email || !req.body.password || !req.body.name) {
     const err = new Error("Malformed Request");
     err.status = 400;
     next(err);
     return;
   }
-  const c = connection.connect(
-    req.app.get("databaseConfig").host,
-    req.app.get("databaseConfig").username,
-    req.app.get("databaseConfig").password,
-    req.app.get("databaseConfig").schema
-  );
-  sqlwrapper
-    .userExists(c, req.body.email)
-    .then(function(userExists) {
-      if (userExists) {
-        const err = new Error("User already exists!");
-        err.status = 409;
-        throw err;
-      } else {
-        return sqlwrapper.createUser(
-          c,
-          req.body.name,
-          req.body.email,
-          req.body.password,
-          0
-        );
-      }
-    })
-    .then(function() {
-      const token = jwt.sign(
-        {
-          id: req.body.email
-        },
-        req.app.get("authConfig").authKey,
-        { expiresIn: req.app.get("authConfig").expiresIn }
+  try {
+    const c = connection.connect(
+      req.app.get("databaseConfig").host,
+      req.app.get("databaseConfig").username,
+      req.app.get("databaseConfig").password,
+      req.app.get("databaseConfig").schema
+    );
+    const userExists = await sqlwrapper.userExists(c, req.body.email);
+    if (userExists) {
+      const err = new Error("User already exists!");
+      err.status = 409;
+      throw err;
+    } else {
+      await sqlwrapper.createUser(
+        c,
+        req.body.name,
+        req.body.email,
+        req.body.password,
+        0
       );
-      res.status(200);
-      res.json({ jwt: token });
-    })
-    .catch(function(err) {
-      err.status = err.status || 500;
-      next(err);
-    });
+    }
+    const token = jwt.sign(
+      {
+        id: req.body.email
+      },
+      req.app.get("authConfig").authKey,
+      { expiresIn: req.app.get("authConfig").expiresIn }
+    );
+    res.status(200);
+    res.json({ jwt: token });
+  } catch (err) {
+    err.status = err.status || 500;
+    next(err);
+  }
 });
 
 module.exports = router;

--- a/backend/controllers/user/register.test.js
+++ b/backend/controllers/user/register.test.js
@@ -44,9 +44,7 @@ async function setupTemporarySchema(host, username, password, temporarySchema) {
   });
   c.connect();
   const setupSchemaQuery = "CREATE SCHEMA " + temporarySchema + ";";
-  await sqlwrapper.executeSQL(c, setupSchemaQuery, []).catch(function(err) {
-    throw err;
-  });
+  await sqlwrapper.executeSQL(c, setupSchemaQuery, []);
   c.destroy();
   const specC = mysql.createConnection({
     host: host,
@@ -62,11 +60,7 @@ async function setupTemporarySchema(host, username, password, temporarySchema) {
         admin BOOL DEFAULT FALSE NOT NULL,
         PRIMARY KEY(email)
     );`;
-  await sqlwrapper
-    .executeSQL(specC, setupUsersTableQuery, [])
-    .catch(function(err) {
-      throw err;
-    });
+  await sqlwrapper.executeSQL(specC, setupUsersTableQuery, []);
   specC.destroy();
 }
 
@@ -83,9 +77,7 @@ async function cleanupTemporarySchema(
   });
   c.connect();
   const setupSchemaQuery = "DROP SCHEMA " + temporarySchema + ";";
-  await sqlwrapper.executeSQL(c, setupSchemaQuery, []).catch(function(err) {
-    throw err;
-  });
+  await sqlwrapper.executeSQL(c, setupSchemaQuery, []);
   c.destroy();
 }
 
@@ -158,18 +150,16 @@ describe("register", () => {
           databaseConfig.password,
           temporarySchema
         );
-        await sqlwrapper
-          .userExists(c, testUserEmail)
-          .then(function(userExists) {
-            if (!userExists) {
-              throw new Error("User was not actually created!");
-            }
-          })
-          .catch(function(err) {
-            throw new Error(
-              "Unexpected error while checking user existence: " + err.message
-            );
-          });
+        try {
+          const userExists = await sqlwrapper.userExists(c, testUserEmail);
+          if (!userExists) {
+            throw new Error("User was not actually created!");
+          }
+        } catch (err) {
+          throw new Error(
+            "Unexpected error while checking user existence: " + err.message
+          );
+        }
       });
     done();
   });
@@ -187,7 +177,7 @@ describe("register", () => {
       .set("Accept", "application/json")
       .expect("Content-Type", /json/)
       .expect(409)
-      .expect(function(res) {
+      .expect(res => {
         const expectedError = "User already exists!";
         if (res.body.message !== expectedError) {
           throw new Error(
@@ -213,7 +203,7 @@ describe("register", () => {
       .set("Accept", "application/json")
       .expect("Content-Type", /json/)
       .expect(400)
-      .expect(function(res) {
+      .expect(res => {
         const expectedError = "Malformed Request";
         if (res.body.message !== expectedError) {
           throw new Error(

--- a/backend/controllers/user/register.test.js
+++ b/backend/controllers/user/register.test.js
@@ -1,183 +1,229 @@
-const request = require('supertest');
-const express = require('express');
-const mysql = require('mysql');
-const jwt = require('jsonwebtoken');
+"use strict";
 
-const config = require('../../config');
-const sqlwrapper = require('../../model/wrapper');
-const connection = require('../../model/connect');
-const register = require('./register');
+const request = require("supertest");
+const express = require("express");
+const mysql = require("mysql");
+const jwt = require("jsonwebtoken");
+
+const config = require("../../config");
+const sqlwrapper = require("../../model/wrapper");
+const connection = require("../../model/connect");
+const register = require("./register");
 
 const app = express();
 app.use(express.json());
 const databaseConfig = {
-    host: config.databaseConfig.host,
-    username: config.databaseConfig.username,
-    password: config.databaseConfig.password,
-    schema: 'tempregisterjestschema',
+  host: config.databaseConfig.host,
+  username: config.databaseConfig.username,
+  password: config.databaseConfig.password,
+  schema: "tempregisterjestschema"
 };
-const authConfig = {authKey: 'registerTestSecret', expiresIn: '1s'};
-app.set('authConfig', authConfig);
-app.set('serverConfig', config.serverConfig);
-app.set('databaseConfig', databaseConfig);
+const authConfig = { authKey: "registerTestSecret", expiresIn: "1s" };
+app.set("authConfig", authConfig);
+app.set("serverConfig", config.serverConfig);
+app.set("databaseConfig", databaseConfig);
 
 function mockErrorHandler(err, req, res, next) {
-    if (err) {
-        res.status(err.status);
-        res.json({status: err.status, message: err.message});
-    } else {
-        res.status(500);
-        res.json({status: 500, message: 'something unexpected happened'});
-    }
+  if (err) {
+    res.status(err.status);
+    res.json({ status: err.status, message: err.message });
+  } else {
+    res.status(500);
+    res.json({ status: 500, message: "something unexpected happened" });
+  }
 }
 
-app.use('/user/register', register);
+app.use("/user/register", register);
 app.use(mockErrorHandler);
 
 async function setupTemporarySchema(host, username, password, temporarySchema) {
-    const c = mysql.createConnection({
-        host: host,
-        user: username,
-        password: password,
-    });
-    c.connect();
-    const setupSchemaQuery = 'CREATE SCHEMA ' + temporarySchema + ';';
-    await sqlwrapper.executeSQL(c, setupSchemaQuery, []).catch(function(err) {
-        throw err;
-    });
-    c.destroy();
-    const specC = mysql.createConnection({
-        host: host,
-        user: username,
-        password: password,
-        database : temporarySchema
-    });
-    specC.connect();
-    const setupUsersTableQuery = 
-    `CREATE TABLE users (
+  const c = mysql.createConnection({
+    host: host,
+    user: username,
+    password: password
+  });
+  c.connect();
+  const setupSchemaQuery = "CREATE SCHEMA " + temporarySchema + ";";
+  await sqlwrapper.executeSQL(c, setupSchemaQuery, []).catch(function(err) {
+    throw err;
+  });
+  c.destroy();
+  const specC = mysql.createConnection({
+    host: host,
+    user: username,
+    password: password,
+    database: temporarySchema
+  });
+  specC.connect();
+  const setupUsersTableQuery = `CREATE TABLE users (
         email VARCHAR(255) NOT NULL UNIQUE CHECK(email REGEXP '^[A-Za-z0-9][A-Za-z0-9]*@[A-Za-z0-9][A-Za-z0-9]*\\.[A-Za-z0-9]*$'),
         password VARCHAR(255) NOT NULL CHECK(passw LIKE '%________%'),
         username VARCHAR(60),
-        admin BOOL DEFAULT FALSE NOT NULL, 
+        admin BOOL DEFAULT FALSE NOT NULL,
         PRIMARY KEY(email)
-    );`
-    await sqlwrapper.executeSQL(specC, setupUsersTableQuery, []).catch(function(err) {
-        throw err;
+    );`;
+  await sqlwrapper
+    .executeSQL(specC, setupUsersTableQuery, [])
+    .catch(function(err) {
+      throw err;
     });
-    specC.destroy();
+  specC.destroy();
 }
 
-async function cleanupTemporarySchema(host, username, password, temporarySchema) {
-    const c = mysql.createConnection({
-        host: host,
-        user: username,
-        password: password,
-    });
-    c.connect();
-    const setupSchemaQuery = 'DROP SCHEMA ' + temporarySchema + ';';
-    await sqlwrapper.executeSQL(c, setupSchemaQuery, []).catch(function(err) {
-        throw err;
-    });
-    c.destroy();
+async function cleanupTemporarySchema(
+  host,
+  username,
+  password,
+  temporarySchema
+) {
+  const c = mysql.createConnection({
+    host: host,
+    user: username,
+    password: password
+  });
+  c.connect();
+  const setupSchemaQuery = "DROP SCHEMA " + temporarySchema + ";";
+  await sqlwrapper.executeSQL(c, setupSchemaQuery, []).catch(function(err) {
+    throw err;
+  });
+  c.destroy();
 }
 
 describe("register", () => {
-    const testUserEmail = 'test@gatech.edu';
-    const testUserPassword = 'testpassword';
-    const testUserName = 'Test User';
-    const temporarySchema = 'tempregisterjestschema';
-    beforeAll(async done => {
-        await setupTemporarySchema(databaseConfig.host, databaseConfig.username, databaseConfig.password, temporarySchema)
-            .catch(function(err) {
-                throw new Error('Unable to create temporary schema: ' + err.message);
-            });
-        done();
+  const testUserEmail = "test@gatech.edu";
+  const testUserPassword = "testpassword";
+  const testUserName = "Test User";
+  const temporarySchema = "tempregisterjestschema";
+  beforeAll(async done => {
+    await setupTemporarySchema(
+      databaseConfig.host,
+      databaseConfig.username,
+      databaseConfig.password,
+      temporarySchema
+    ).catch(function(err) {
+      throw new Error("Unable to create temporary schema: " + err.message);
     });
-    
-    afterAll(async done => {
-        await cleanupTemporarySchema(databaseConfig.host,
-            databaseConfig.username, databaseConfig.password, temporarySchema).catch(function(err) {
-                throw new Error('Unable to cleanup temporary schema: ' + err.message);
-            });
-        done();
+    done();
+  });
+
+  afterAll(async done => {
+    await cleanupTemporarySchema(
+      databaseConfig.host,
+      databaseConfig.username,
+      databaseConfig.password,
+      temporarySchema
+    ).catch(function(err) {
+      throw new Error("Unable to cleanup temporary schema: " + err.message);
     });
-    
-    test("Register Success", async done => {
-        const registerObject = {
-            email: testUserEmail,
-            password: testUserPassword,
-            name: testUserName
-        };
-        await request(app)
-            .post('/user/register')
-            .send(registerObject)
-            .set('Content-Type', 'application/json')
-            .set('Accept', 'application/json')
-            .expect('Content-Type', /json/)
-            .expect(200)
-            .expect(async function(res) {
-                try {
-                    const payload = jwt.verify(res.body.jwt, app.get('authConfig').authKey);
-                    if (payload.id !== testUserEmail) {
-                        throw new Error('Unexpected ID, expected ' + testUserEmail + ', got ' + payload.id + ' instead');
-                    }
-                } catch(e) {
-                    e.message = 'Returned JWT is not valid for some reason or another: ' + e.message;
-                    throw e;
-                }
-                const c = connection.connect(databaseConfig.host,
-                    databaseConfig.username, databaseConfig.password, temporarySchema);
-                await sqlwrapper.userExists(c, testUserEmail).then(function(userExists) {
-                    if (!userExists) {
-                        throw new Error('User was not actually created!');
-                    }
-                }).catch(function(err) {
-                    throw new Error('Unexpected error while checking user existence: ' + err.message);
-                });
-            });
-        done();
-    });
-    
-    test("Register Duplicate", async done => {
-        const registerObject = {
-            email: testUserEmail,
-            password: testUserPassword,
-            name: testUserName
-        };
-        await request(app)
-            .post('/user/register')
-            .send(registerObject)
-            .set('Content-Type', 'application/json')
-            .set('Accept', 'application/json')
-            .expect('Content-Type', /json/)
-            .expect(409)
-            .expect(function(res) {
-                const expectedError = 'User already exists!';
-                if (res.body.message !== expectedError) {
-                    throw new Error('Expected error: ' + expectedError + ', received: ' + res.body.message);
-                }
-            });
-        done();
-    });
-    test("Register Malformed", async done => {
-        const registerObject = {
-            emaiel: testUserEmail,
-            passwords: testUserPassword,
-            namee: testUserName
-        };
-        await request(app)
-            .post('/user/register')
-            .send(registerObject)
-            .set('Content-Type', 'application/json')
-            .set('Accept', 'application/json')
-            .expect('Content-Type', /json/)
-            .expect(400)
-            .expect(function(res) {
-                const expectedError = 'Malformed Request';
-                if (res.body.message !== expectedError) {
-                    throw new Error('Expected error: ' + expectedError + ', received: ' + res.body.message);
-                }
-            });
-        done();
-    });
+    done();
+  });
+
+  test("Register Success", async done => {
+    const registerObject = {
+      email: testUserEmail,
+      password: testUserPassword,
+      name: testUserName
+    };
+    await request(app)
+      .post("/user/register")
+      .send(registerObject)
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json")
+      .expect("Content-Type", /json/)
+      .expect(200)
+      .expect(async function(res) {
+        try {
+          const payload = jwt.verify(
+            res.body.jwt,
+            app.get("authConfig").authKey
+          );
+          if (payload.id !== testUserEmail) {
+            throw new Error(
+              "Unexpected ID, expected " +
+                testUserEmail +
+                ", got " +
+                payload.id +
+                " instead"
+            );
+          }
+        } catch (e) {
+          e.message =
+            "Returned JWT is not valid for some reason or another: " +
+            e.message;
+          throw e;
+        }
+        const c = connection.connect(
+          databaseConfig.host,
+          databaseConfig.username,
+          databaseConfig.password,
+          temporarySchema
+        );
+        await sqlwrapper
+          .userExists(c, testUserEmail)
+          .then(function(userExists) {
+            if (!userExists) {
+              throw new Error("User was not actually created!");
+            }
+          })
+          .catch(function(err) {
+            throw new Error(
+              "Unexpected error while checking user existence: " + err.message
+            );
+          });
+      });
+    done();
+  });
+
+  test("Register Duplicate", async done => {
+    const registerObject = {
+      email: testUserEmail,
+      password: testUserPassword,
+      name: testUserName
+    };
+    await request(app)
+      .post("/user/register")
+      .send(registerObject)
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json")
+      .expect("Content-Type", /json/)
+      .expect(409)
+      .expect(function(res) {
+        const expectedError = "User already exists!";
+        if (res.body.message !== expectedError) {
+          throw new Error(
+            "Expected error: " +
+              expectedError +
+              ", received: " +
+              res.body.message
+          );
+        }
+      });
+    done();
+  });
+  test("Register Malformed", async done => {
+    const registerObject = {
+      emaiel: testUserEmail,
+      passwords: testUserPassword,
+      namee: testUserName
+    };
+    await request(app)
+      .post("/user/register")
+      .send(registerObject)
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json")
+      .expect("Content-Type", /json/)
+      .expect(400)
+      .expect(function(res) {
+        const expectedError = "Malformed Request";
+        if (res.body.message !== expectedError) {
+          throw new Error(
+            "Expected error: " +
+              expectedError +
+              ", received: " +
+              res.body.message
+          );
+        }
+      });
+    done();
+  });
 });

--- a/backend/controllers/user/renew.js
+++ b/backend/controllers/user/renew.js
@@ -1,14 +1,19 @@
-const express = require('express');
-const jwt = require('jsonwebtoken');
+"use strict";
+
+const express = require("express");
+const jwt = require("jsonwebtoken");
 const router = express.Router();
 
-router.get('', function(req, res, next) {
-    const token = jwt.sign(
-        {
-            id: req.headers.id
-        }, req.app.get('authConfig').authKey, { expiresIn: req.app.get('authConfig').expiresIn });
-    res.status(200);
-    res.json({jwt: token});
+router.get("", function(req, res, next) {
+  const token = jwt.sign(
+    {
+      id: req.headers.id
+    },
+    req.app.get("authConfig").authKey,
+    { expiresIn: req.app.get("authConfig").expiresIn }
+  );
+  res.status(200);
+  res.json({ jwt: token });
 });
 
 module.exports = router;

--- a/backend/controllers/user/renew.js
+++ b/backend/controllers/user/renew.js
@@ -4,7 +4,7 @@ const express = require("express");
 const jwt = require("jsonwebtoken");
 const router = express.Router();
 
-router.get("", function(req, res, next) {
+router.get("", (req, res, next) => {
   const token = jwt.sign(
     {
       id: req.headers.id

--- a/backend/controllers/user/renew.test.js
+++ b/backend/controllers/user/renew.test.js
@@ -1,33 +1,46 @@
-const request = require('supertest');
-const express = require('express');
-const jwt = require('jsonwebtoken');
+"use strict";
 
-const renew = require('./renew');
+const request = require("supertest");
+const express = require("express");
+const jwt = require("jsonwebtoken");
+
+const renew = require("./renew");
 
 const app = express();
-const authConfig = {authKey: 'renewTestSecret', expiresIn: '1s'};
-app.set('authConfig', authConfig);
-app.use('/user/renew', renew);
+const authConfig = { authKey: "renewTestSecret", expiresIn: "1s" };
+app.set("authConfig", authConfig);
+app.use("/user/renew", renew);
 
 describe("renew", () => {
-    test("Return a valid JWT", async done => {
-        const expectedId = 'test@gatech.edu';
-        await request(app)
-            .get('/user/renew')
-            .set('id', expectedId)
-            .expect('Content-Type', /json/)
-            .expect(200)
-            .expect(function(res) {
-                try {
-                    const payload = jwt.verify(res.body.jwt, app.get('authConfig').authKey);
-                    if (payload.id !== expectedId) {
-                        throw new Error('Unexpected ID, expected ' + expectedId + ', got ' + payload.id + ' instead');
-                    }
-                } catch(e) {
-                    e.message = 'Returned JWT is not valid for some reason or another: ' + e.message;
-                    throw e;
-                }
-            });
-        done();
-    });
+  test("Return a valid JWT", async done => {
+    const expectedId = "test@gatech.edu";
+    await request(app)
+      .get("/user/renew")
+      .set("id", expectedId)
+      .expect("Content-Type", /json/)
+      .expect(200)
+      .expect(function(res) {
+        try {
+          const payload = jwt.verify(
+            res.body.jwt,
+            app.get("authConfig").authKey
+          );
+          if (payload.id !== expectedId) {
+            throw new Error(
+              "Unexpected ID, expected " +
+                expectedId +
+                ", got " +
+                payload.id +
+                " instead"
+            );
+          }
+        } catch (e) {
+          e.message =
+            "Returned JWT is not valid for some reason or another: " +
+            e.message;
+          throw e;
+        }
+      });
+    done();
+  });
 });

--- a/backend/controllers/user/renew.test.js
+++ b/backend/controllers/user/renew.test.js
@@ -19,7 +19,7 @@ describe("renew", () => {
       .set("id", expectedId)
       .expect("Content-Type", /json/)
       .expect(200)
-      .expect(function(res) {
+      .expect(res => {
         try {
           const payload = jwt.verify(
             res.body.jwt,

--- a/backend/middleware/auth/verify.js
+++ b/backend/middleware/auth/verify.js
@@ -1,26 +1,30 @@
-const express = require('express');
-const jwt = require('jsonwebtoken');
+"use strict";
+
+const jwt = require("jsonwebtoken");
 
 function verifyToken(req, res, next) {
-    try {
-        const payload = jwt.verify(retrieveToken(req), req.app.get('authConfig').authKey);
-        req.headers.id = payload.id;
-    } catch (e) {
-        e.status = 401;
-        next(e);
-    }
-    next();
+  try {
+    const payload = jwt.verify(
+      retrieveToken(req),
+      req.app.get("authConfig").authKey
+    );
+    req.headers.id = payload.id;
+  } catch (e) {
+    e.status = 401;
+    next(e);
+  }
+  next();
 }
 
 function retrieveToken(req) {
-    if (!req.headers.authorization) {
-        return null;
-    }
-    const auth = req.headers.authorization.split(' ');
-    if (auth[0] === 'Bearer' && auth[1]) {
-        return auth[1];
-    }
+  if (!req.headers.authorization) {
     return null;
+  }
+  const auth = req.headers.authorization.split(" ");
+  if (auth[0] === "Bearer" && auth[1]) {
+    return auth[1];
+  }
+  return null;
 }
 
 module.exports = verifyToken;

--- a/backend/middleware/auth/verify.test.js
+++ b/backend/middleware/auth/verify.test.js
@@ -1,111 +1,146 @@
-const request = require('supertest');
-const express = require('express');
-const jwt = require('jsonwebtoken');
+"use strict";
 
-const verify = require('./verify');
+const request = require("supertest");
+const express = require("express");
+const jwt = require("jsonwebtoken");
+
+const verify = require("./verify");
 
 const app = express();
 
-const authConfig = {authKey: 'verifyTestSecret', expiresIn: '1s'};
-app.set('authConfig', authConfig);
+const authConfig = { authKey: "verifyTestSecret", expiresIn: "1s" };
+app.set("authConfig", authConfig);
 
 const mockSuccessRouter = express.Router();
-mockSuccessRouter.get('', function(req, res, next) {
-    res.status(200);
-    res.json({status: 200, message: 'success'});
+mockSuccessRouter.get("", function(req, res, next) {
+  res.status(200);
+  res.json({ status: 200, message: "success" });
 });
 
 function mockErrorHandler(err, req, res, next) {
-    if (err) {
-        res.status(err.status);
-        res.json({status: err.status, message: err.message});
-    } else {
-        res.status(500);
-        res.json({status: 500, message: 'something unexpected happened'});
-    }
+  if (err) {
+    res.status(err.status);
+    res.json({ status: err.status, message: err.message });
+  } else {
+    res.status(500);
+    res.json({ status: 500, message: "something unexpected happened" });
+  }
 }
 
 app.use("/", verify, mockSuccessRouter);
 app.use(mockErrorHandler);
 
 describe("verify", () => {
-    test("Allow valid JWT", async done => {
-        const expectedId = 'test@gatech.edu';
-        const expiresIn = '1s';
-        await request(app)
-            .get('/')
-            .set('id', expectedId)
-            .set('Authorization', 'Bearer ' + jwt.sign({id: expectedId}, app.get('authConfig').authKey), {expiresIn: expiresIn})
-            .expect('Content-Type', /json/)
-            .expect(200);
-        done();
-    });
+  test("Allow valid JWT", async done => {
+    const expectedId = "test@gatech.edu";
+    const expiresIn = "1s";
+    await request(app)
+      .get("/")
+      .set("id", expectedId)
+      .set(
+        "Authorization",
+        "Bearer " + jwt.sign({ id: expectedId }, app.get("authConfig").authKey),
+        { expiresIn: expiresIn }
+      )
+      .expect("Content-Type", /json/)
+      .expect(200);
+    done();
+  });
 
-    test("Disallow no JWT", async done => {
-        const expectedId = 'test@gatech.edu';
-        await request(app)
-            .get('/')
-            .set('id', expectedId)
-            .expect('Content-Type', /json/)
-            .expect(401)
-            .expect(function(res) {
-                const expectedError = 'jwt must be provided';
-                if (res.body.message !== expectedError) {
-                    throw new Error('Expected error: ' + expectedError + ', received: ' + res.body.message);
-                }
-            });
-        done();
-    });
+  test("Disallow no JWT", async done => {
+    const expectedId = "test@gatech.edu";
+    await request(app)
+      .get("/")
+      .set("id", expectedId)
+      .expect("Content-Type", /json/)
+      .expect(401)
+      .expect(function(res) {
+        const expectedError = "jwt must be provided";
+        if (res.body.message !== expectedError) {
+          throw new Error(
+            "Expected error: " +
+              expectedError +
+              ", received: " +
+              res.body.message
+          );
+        }
+      });
+    done();
+  });
 
-    test("Disallow invalid JWT", async done => {
-        const expectedId = 'test@gatech.edu';
-        await request(app)
-            .get('/')
-            .set('id', expectedId)
-            .set('Authorization', 'Bearer ' + jwt.sign({id: expectedId}, 'incorrect_key'))
-            .expect('Content-Type', /json/)
-            .expect(401)
-            .expect(function(res) {
-                const expectedError = 'invalid signature';
-                if (res.body.message !== expectedError) {
-                    throw new Error('Expected error: ' + expectedError + ', received: ' + res.body.message);
-                }
-            });
-        done();
-    });
+  test("Disallow invalid JWT", async done => {
+    const expectedId = "test@gatech.edu";
+    await request(app)
+      .get("/")
+      .set("id", expectedId)
+      .set(
+        "Authorization",
+        "Bearer " + jwt.sign({ id: expectedId }, "incorrect_key")
+      )
+      .expect("Content-Type", /json/)
+      .expect(401)
+      .expect(function(res) {
+        const expectedError = "invalid signature";
+        if (res.body.message !== expectedError) {
+          throw new Error(
+            "Expected error: " +
+              expectedError +
+              ", received: " +
+              res.body.message
+          );
+        }
+      });
+    done();
+  });
 
-    test("Disallow expired JWT", async done => {
-        const expectedId = 'test@gatech.edu';
-        const expiresIn = '-1s';
-        await request(app)
-            .get('/')
-            .set('id', expectedId)
-            .set('Authorization', 'Bearer ' + jwt.sign({id: expectedId}, app.get('authConfig').authKey, {expiresIn: expiresIn}))
-            .expect('Content-Type', /json/)
-            .expect(401)
-            .expect(function(res) {
-                const expectedError = 'jwt expired';
-                if (res.body.message !== expectedError) {
-                    throw new Error('Expected error: ' + expectedError + ', received: ' + res.body.message);
-                }
-            });
-        done();
-    });
-    
-    test("Disallow malformed JWT", async done => {
-        const expectedId = 'test@gatech.edu';
-        await request(app)
-            .get('/')
-            .set('id', expectedId)
-            .set('Authorization', 'Bearer abcde')
-            .expect('Content-Type', /json/)
-            .expect(401)
-            .expect(function(res) {
-                const expectedError = 'jwt malformed';
-                if (res.body.message !== expectedError) {
-                    throw new Error('Expected error: ' + expectedError + ', received: ' + res.body.message);
-                }
-            });
-        done();
-    });
+  test("Disallow expired JWT", async done => {
+    const expectedId = "test@gatech.edu";
+    const expiresIn = "-1s";
+    await request(app)
+      .get("/")
+      .set("id", expectedId)
+      .set(
+        "Authorization",
+        "Bearer " +
+          jwt.sign({ id: expectedId }, app.get("authConfig").authKey, {
+            expiresIn: expiresIn
+          })
+      )
+      .expect("Content-Type", /json/)
+      .expect(401)
+      .expect(function(res) {
+        const expectedError = "jwt expired";
+        if (res.body.message !== expectedError) {
+          throw new Error(
+            "Expected error: " +
+              expectedError +
+              ", received: " +
+              res.body.message
+          );
+        }
+      });
+    done();
+  });
+
+  test("Disallow malformed JWT", async done => {
+    const expectedId = "test@gatech.edu";
+    await request(app)
+      .get("/")
+      .set("id", expectedId)
+      .set("Authorization", "Bearer abcde")
+      .expect("Content-Type", /json/)
+      .expect(401)
+      .expect(function(res) {
+        const expectedError = "jwt malformed";
+        if (res.body.message !== expectedError) {
+          throw new Error(
+            "Expected error: " +
+              expectedError +
+              ", received: " +
+              res.body.message
+          );
+        }
+      });
+    done();
+  });
 });

--- a/backend/model/connect.js
+++ b/backend/model/connect.js
@@ -1,16 +1,18 @@
-const mysql = require('mysql');
+"use strict";
+
+const mysql = require("mysql");
 
 function connect(host, username, password, database) {
-    const connection = mysql.createConnection({
-        host: host,
-        user: username,
-        password: password,
-        database: database
-    });
-    connection.connect();
-    return connection;
+  const connection = mysql.createConnection({
+    host: host,
+    user: username,
+    password: password,
+    database: database
+  });
+  connection.connect();
+  return connection;
 }
 
 module.exports = {
-    connect: connect,
+  connect: connect
 };

--- a/backend/model/connect.test.js
+++ b/backend/model/connect.test.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const config = require("../config");
+const connection = require("./connect");
+
+const databaseConfig = {
+  host: config.databaseConfig.host,
+  username: config.databaseConfig.username,
+  password: config.databaseConfig.password,
+  schema: "temploginjestschema"
+};
+
+describe("connect", () => {
+  test("Connect to the MySQL database", done => {
+    const c = connection.connect(
+      databaseConfig.host,
+      databaseConfig.username,
+      databaseConfig.password,
+      databaseConfig.schema
+    );
+    c.destroy();
+    done();
+  });
+});

--- a/backend/model/wrapper.js
+++ b/backend/model/wrapper.js
@@ -3,27 +3,26 @@
 const bcrypt = require("bcrypt");
 const saltRounds = 10;
 
-async function createUser(connection, uname, email, password, admin) {
-  return bcrypt.hash(password, saltRounds).then(function(hash) {
-    const query =
-      "INSERT INTO users(email, password, userName, admin) VALUES(?, ?, ?, ?)";
-    return new Promise(function(resolve, reject) {
-      connection.query(query, [email, hash, uname, admin], function(
-        err,
-        rows,
-        fields
-      ) {
-        if (err) {
-          reject(err);
-        } else {
-          resolve();
-        }
-      });
+function createUser(connection, uname, email, password, admin) {
+  const query =
+    "INSERT INTO users(email, password, userName, admin) VALUES(?, ?, ?, ?)";
+  return new Promise(async (resolve, reject) => {
+    const hash = await bcrypt.hash(password, saltRounds);
+    connection.query(query, [email, hash, uname, admin], function(
+      err,
+      rows,
+      fields
+    ) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
     });
   });
 }
 
-async function userExists(connection, email) {
+function userExists(connection, email) {
   const query = "SELECT userName FROM users WHERE email = ?;";
   return new Promise(function(resolve, reject) {
     connection.query(query, [email], function(err, rows, fields) {
@@ -36,7 +35,7 @@ async function userExists(connection, email) {
   });
 }
 
-async function checkCredentials(connection, email, password) {
+function checkCredentials(connection, email, password) {
   const query = "SELECT password FROM users WHERE email = ?;";
   return new Promise(function(resolve, reject) {
     connection.query(query, [email], function(err, rows, fields) {
@@ -55,7 +54,7 @@ async function checkCredentials(connection, email, password) {
   });
 }
 
-async function executeSQL(connection, sql, varList) {
+function executeSQL(connection, sql, varList) {
   return new Promise(function(resolve, reject) {
     connection.query(sql, varList, function(err, rows, fields) {
       if (err) {

--- a/backend/model/wrapper.js
+++ b/backend/model/wrapper.js
@@ -1,68 +1,75 @@
-const bcrypt = require('bcrypt');
+"use strict";
+
+const bcrypt = require("bcrypt");
 const saltRounds = 10;
 
 async function createUser(connection, uname, email, password, admin) {
-    return bcrypt.hash(password, saltRounds).then(function(hash) {
-        const query = 'INSERT INTO users(email, password, userName, admin) VALUES(?, ?, ?, ?)';
-        return new Promise(function(resolve, reject) {
-            connection.query(query, [email, hash, uname, admin], function(err, rows, fields) {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve();
-                }
-            });
-        });
+  return bcrypt.hash(password, saltRounds).then(function(hash) {
+    const query =
+      "INSERT INTO users(email, password, userName, admin) VALUES(?, ?, ?, ?)";
+    return new Promise(function(resolve, reject) {
+      connection.query(query, [email, hash, uname, admin], function(
+        err,
+        rows,
+        fields
+      ) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
     });
+  });
 }
 
 async function userExists(connection, email) {
-    const query = 'SELECT userName FROM users WHERE email = ?;';
-    return new Promise(function(resolve, reject) {
-        connection.query(query, [email], function (err, rows, fields) {
-            if (err) {
-                reject(err);
-            } else {
-                resolve(rows.length > 0);
-            }
-        });
+  const query = "SELECT userName FROM users WHERE email = ?;";
+  return new Promise(function(resolve, reject) {
+    connection.query(query, [email], function(err, rows, fields) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(rows.length > 0);
+      }
     });
+  });
 }
 
 async function checkCredentials(connection, email, password) {
-    const query = 'SELECT password FROM users WHERE email = ?;';
-    return new Promise(function(resolve, reject) {
-        connection.query(query, [email], function(err, rows, fields) {
-            if (err) {
-                reject(err);
-            } else {
-                resolve(rows);
-            }
-        });
-    }).then(function(rows) {
-        if (rows.length > 0) {
-            return bcrypt.compare(password, rows[0].password);
-        } else {
-            return false;
-        }
+  const query = "SELECT password FROM users WHERE email = ?;";
+  return new Promise(function(resolve, reject) {
+    connection.query(query, [email], function(err, rows, fields) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(rows);
+      }
     });
-};
+  }).then(function(rows) {
+    if (rows.length > 0) {
+      return bcrypt.compare(password, rows[0].password);
+    } else {
+      return false;
+    }
+  });
+}
 
 async function executeSQL(connection, sql, varList) {
-    return new Promise(function(resolve, reject) {
-        connection.query(sql, varList, function(err, rows, fields) {
-            if (err) {
-                reject(err);
-            } else {
-                resolve(rows, fields);
-            }
-        });
+  return new Promise(function(resolve, reject) {
+    connection.query(sql, varList, function(err, rows, fields) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(rows, fields);
+      }
     });
+  });
 }
 
 module.exports = {
-    checkCredentials: checkCredentials,
-    createUser: createUser,
-    userExists: userExists,
-    executeSQL: executeSQL
+  checkCredentials: checkCredentials,
+  createUser: createUser,
+  userExists: userExists,
+  executeSQL: executeSQL
 };

--- a/backend/model/wrapper.js
+++ b/backend/model/wrapper.js
@@ -24,7 +24,7 @@ function createUser(connection, uname, email, password, admin) {
 
 function userExists(connection, email) {
   const query = "SELECT userName FROM users WHERE email = ?;";
-  return new Promise(function(resolve, reject) {
+  return new Promise((resolve, reject) => {
     connection.query(query, [email], function(err, rows, fields) {
       if (err) {
         reject(err);
@@ -37,7 +37,7 @@ function userExists(connection, email) {
 
 function checkCredentials(connection, email, password) {
   const query = "SELECT password FROM users WHERE email = ?;";
-  return new Promise(function(resolve, reject) {
+  return new Promise((resolve, reject) => {
     connection.query(query, [email], function(err, rows, fields) {
       if (err) {
         reject(err);
@@ -55,7 +55,7 @@ function checkCredentials(connection, email, password) {
 }
 
 function executeSQL(connection, sql, varList) {
-  return new Promise(function(resolve, reject) {
+  return new Promise((resolve, reject) => {
     connection.query(sql, varList, function(err, rows, fields) {
       if (err) {
         reject(err);

--- a/backend/model/wrapper.test.js
+++ b/backend/model/wrapper.test.js
@@ -1,0 +1,253 @@
+"use strict";
+
+const mysql = require("mysql");
+const bcrypt = require("bcrypt");
+
+const config = require("../config");
+const sqlwrapper = require("./wrapper");
+const connection = require("./connect");
+
+const databaseConfig = {
+  host: config.databaseConfig.host,
+  username: config.databaseConfig.username,
+  password: config.databaseConfig.password,
+  schema: "tempwrapperjestschema"
+};
+
+async function setupTemporarySchema(host, username, password, temporarySchema) {
+  const c = mysql.createConnection({
+    host: host,
+    user: username,
+    password: password
+  });
+  c.connect();
+  const setupSchemaQuery = "CREATE SCHEMA " + temporarySchema + ";";
+  await sqlwrapper.executeSQL(c, setupSchemaQuery, []);
+  c.destroy();
+  const specC = mysql.createConnection({
+    host: host,
+    user: username,
+    password: password,
+    database: temporarySchema
+  });
+  specC.connect();
+  const setupUsersTableQuery = `CREATE TABLE users (
+        email VARCHAR(255) NOT NULL UNIQUE CHECK(email REGEXP '^[A-Za-z0-9][A-Za-z0-9]*@[A-Za-z0-9][A-Za-z0-9]*\\.[A-Za-z0-9]*$'),
+        password VARCHAR(255) NOT NULL CHECK(passw LIKE '%________%'),
+        username VARCHAR(60),
+        admin BOOL DEFAULT FALSE NOT NULL,
+        PRIMARY KEY(email)
+    );`;
+  await sqlwrapper.executeSQL(specC, setupUsersTableQuery, []);
+  specC.destroy();
+}
+
+async function cleanupTemporarySchema(
+  host,
+  username,
+  password,
+  temporarySchema
+) {
+  const c = mysql.createConnection({
+    host: host,
+    user: username,
+    password: password
+  });
+  c.connect();
+  const setupSchemaQuery = "DROP SCHEMA " + temporarySchema + ";";
+  await sqlwrapper.executeSQL(c, setupSchemaQuery, []);
+  c.destroy();
+}
+
+describe("sql wrapper", () => {
+  beforeAll(async () => {
+    await setupTemporarySchema(
+      databaseConfig.host,
+      databaseConfig.username,
+      databaseConfig.password,
+      databaseConfig.schema
+    );
+  });
+
+  afterAll(async () => {
+    await cleanupTemporarySchema(
+      databaseConfig.host,
+      databaseConfig.username,
+      databaseConfig.password,
+      databaseConfig.schema
+    );
+  });
+
+  test("Execute SQL", async done => {
+    const testQuery = "SELECT * FROM users;";
+    const c = connection.connect(
+      databaseConfig.host,
+      databaseConfig.username,
+      databaseConfig.password,
+      databaseConfig.schema
+    );
+    const result = await sqlwrapper.executeSQL(c, testQuery, []);
+    if (!result) {
+      throw new Error("Something went wrong.");
+    }
+    if (result.length !== 0) {
+      throw new Error(
+        "Row count not 0 as expected, got " + result.length.toString()
+      );
+    }
+    done();
+  });
+
+  test("Create user", async done => {
+    const testGetUsers = "SELECT * FROM users;";
+    const testUserName = "Test Create User";
+    const testUserEmail = "testCreateUser@gatech.edu";
+    const testUserPassword = "testcreateuserpassword";
+    const c = connection.connect(
+      databaseConfig.host,
+      databaseConfig.username,
+      databaseConfig.password,
+      databaseConfig.schema
+    );
+    await sqlwrapper.createUser(
+      c,
+      testUserName,
+      testUserEmail,
+      testUserPassword,
+      0
+    );
+    const result = await sqlwrapper.executeSQL(c, testGetUsers, []);
+    c.destroy();
+    if (!result) {
+      throw new Error("Something went wrong.");
+    }
+    if (result.length !== 1) {
+      throw new Error(
+        "Row count not 1 as expected, got " + result.length.toString()
+      );
+    }
+    const email = result[0].email;
+    const password = result[0].password;
+    const name = result[0].username;
+    if (email !== testUserEmail) {
+      throw new Error(
+        "Email is not as expected, should be: " +
+          testUserEmail +
+          ", instead got: " +
+          email
+      );
+    }
+    if (name !== testUserName) {
+      throw new Error(
+        "Name is not as expected, should be: " +
+          testUserName +
+          ", instead got: " +
+          name
+      );
+    }
+    const correctPassword = await bcrypt.compare(testUserPassword, password);
+    if (!correctPassword) {
+      throw new Error("Password match failed.");
+    }
+    done();
+  });
+
+  test("User Exists", async done => {
+    const testUserEmail = "testUserExists@gatech.edu";
+    const testUserName = "Test User Exists";
+    const testUserPassword = "testuserexistspassword";
+    const insertUserQuery =
+      "INSERT INTO users(email, password, username, admin) VALUES (?, ?, ?, false);";
+    const c = connection.connect(
+      databaseConfig.host,
+      databaseConfig.username,
+      databaseConfig.password,
+      databaseConfig.schema
+    );
+    await sqlwrapper.executeSQL(c, insertUserQuery, [
+      testUserEmail,
+      testUserPassword,
+      testUserName
+    ]);
+    const exists = await sqlwrapper.userExists(c, testUserEmail);
+    c.destroy();
+    if (!exists) {
+      throw new Error(
+        "Expected for user to exist, instead got user does not exist."
+      );
+    }
+    done();
+  });
+
+  test("Check Valid Credentials", async done => {
+    const saltrounds = 10;
+    const testUserEmail = "testCheckValidCredentials@gatech.edu";
+    const testUserName = "Test Check Valid Credentials";
+    const testUserPassword = "testcheckvalidcredentialspassword";
+    const testUserHashedPassword = await bcrypt.hash(
+      testUserPassword,
+      saltrounds
+    );
+    const insertUserQuery =
+      "INSERT INTO users(email, password, username, admin) VALUES (?, ?, ?, false);";
+    const c = connection.connect(
+      databaseConfig.host,
+      databaseConfig.username,
+      databaseConfig.password,
+      databaseConfig.schema
+    );
+    await sqlwrapper.executeSQL(c, insertUserQuery, [
+      testUserEmail,
+      testUserHashedPassword,
+      testUserName
+    ]);
+    const validCredentials = await sqlwrapper.checkCredentials(
+      c,
+      testUserEmail,
+      testUserPassword
+    );
+    c.destroy();
+    if (!validCredentials) {
+      throw new Error(
+        "Expected valid credentials, instead got invalid credentials."
+      );
+    }
+    done();
+  });
+
+  test("Check Invalid Credentials", async done => {
+    const saltrounds = 10;
+    const testUserEmail = "testCheckInvalidCredentials@gatech.edu";
+    const testUserName = "Test Check Invalid Credentials";
+    const testUserPassword = "testcheckinvalidcredentialspassword";
+    const testUserHashedPassword = await bcrypt.hash(
+      testUserPassword,
+      saltrounds
+    );
+    const insertUserQuery =
+      "INSERT INTO users(email, password, username, admin) VALUES (?, ?, ?, false);";
+    const c = connection.connect(
+      databaseConfig.host,
+      databaseConfig.username,
+      databaseConfig.password,
+      databaseConfig.schema
+    );
+    await sqlwrapper.executeSQL(c, insertUserQuery, [
+      testUserEmail,
+      testUserHashedPassword,
+      testUserName
+    ]);
+    const validCredentials = await sqlwrapper.checkCredentials(
+      c,
+      testUserEmail,
+      "invalid credentials"
+    );
+    c.destroy();
+    if (validCredentials) {
+      throw new Error(
+        "Expected invalid credentials, instead got valid credentials."
+      );
+    }
+    done();
+  });
+});

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1592,6 +1592,12 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
     "content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
@@ -2075,6 +2081,160 @@
           "dev": true
         }
       }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+          "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.5"
+          }
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
+      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "pkg-dir": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
+      "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+      "dev": true,
+      "requires": {
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.8",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.1",
+        "eslint-module-utils": "^2.2.0",
+        "has": "^1.0.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.3",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.6.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+          "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.5"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
+      "integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "4.0.0",
@@ -5146,6 +5306,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.2.tgz",
+      "integrity": "sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==",
       "dev": true
     },
     "pretty-format": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -32,6 +32,15 @@
         }
       }
     },
+    "@samverschueren/stream-to-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
+      "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+      "dev": true,
+      "requires": {
+        "any-observable": "^0.3.0"
+      }
+    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -109,6 +118,12 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "any-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+      "dev": true
     },
     "anymatch": {
       "version": "2.0.0",
@@ -1510,6 +1525,53 @@
         "restore-cursor": "^2.0.0"
       }
     },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "^1.0.1"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "slice-ansi": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
@@ -1577,8 +1639,7 @@
       "version": "2.17.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
       "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -1650,6 +1711,29 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cosmiconfig": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
+      "integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
+      "dev": true,
+      "requires": {
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.9.0",
+        "parse-json": "^4.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -1709,6 +1793,12 @@
         }
       }
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
     "date-format": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-1.2.0.tgz",
@@ -1732,6 +1822,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
     "deep-is": {
@@ -1904,6 +2000,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -2339,6 +2441,12 @@
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -2560,6 +2668,12 @@
         "statuses": "~1.4.0",
         "unpipe": "~1.0.0"
       }
+    },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
     },
     "find-up": {
       "version": "2.1.0",
@@ -3200,6 +3314,12 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
+      "dev": true
+    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -3453,6 +3573,25 @@
         "sshpk": "^1.7.0"
       }
     },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "^1.0.10",
+        "normalize-path": "^1.0.0",
+        "strip-indent": "^2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -3478,6 +3617,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
     },
     "inflight": {
@@ -3615,6 +3760,12 @@
         }
       }
     },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -3679,6 +3830,21 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-observable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "^1.1.0"
       }
     },
     "is-path-cwd": {
@@ -3748,6 +3914,12 @@
       "requires": {
         "has": "^1.0.1"
       }
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
     },
     "is-resolvable": {
       "version": "1.1.0",
@@ -4388,6 +4560,12 @@
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -4518,6 +4696,543 @@
         "type-check": "~0.3.2"
       }
     },
+    "lint-staged": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-7.2.2.tgz",
+      "integrity": "sha512-BWT3kx242hq5oaKJ8QiazPeHwJnEXImvjmgZfjljMI5HX6RrTxI3cTJXywre6GNafMONCD/suFnEiFmC69Gscg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.1",
+        "commander": "^2.14.1",
+        "cosmiconfig": "^5.0.2",
+        "debug": "^3.1.0",
+        "dedent": "^0.7.0",
+        "execa": "^0.9.0",
+        "find-parent-dir": "^0.3.0",
+        "is-glob": "^4.0.0",
+        "is-windows": "^1.0.2",
+        "jest-validate": "^23.5.0",
+        "listr": "^0.14.1",
+        "lodash": "^4.17.5",
+        "log-symbols": "^2.2.0",
+        "micromatch": "^3.1.8",
+        "npm-which": "^3.0.1",
+        "p-map": "^1.1.1",
+        "path-is-inside": "^1.0.2",
+        "pify": "^3.0.0",
+        "please-upgrade-node": "^3.0.2",
+        "staged-git-files": "1.1.1",
+        "string-argv": "^0.0.2",
+        "stringify-object": "^3.2.2"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
+          "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "listr": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.2.tgz",
+      "integrity": "sha512-vmaNJ1KlGuGWShHI35X/F8r9xxS0VTHh9GejVXwSN20fG5xpq3Jh4bJbnumoT6q5EDM/8/YP1z3YMtQbFmhuXw==",
+      "dev": true,
+      "requires": {
+        "@samverschueren/stream-to-observable": "^0.3.0",
+        "is-observable": "^1.1.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.4.0",
+        "listr-verbose-renderer": "^0.4.0",
+        "p-map": "^1.1.1",
+        "rxjs": "^6.1.0"
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^1.0.2",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-cursor": "^1.0.2",
+        "date-fns": "^1.27.2",
+        "figures": "^1.7.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -4587,6 +5302,58 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
+    },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^1.0.0",
+        "cli-cursor": "^1.0.2"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        }
+      }
     },
     "log4js": {
       "version": "3.0.5",
@@ -4927,6 +5694,15 @@
         "remove-trailing-separator": "^1.0.1"
       }
     },
+    "npm-path": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
+      "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
+      "dev": true,
+      "requires": {
+        "which": "^1.2.10"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -4934,6 +5710,17 @@
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.9.0",
+        "npm-path": "^2.0.2",
+        "which": "^1.2.10"
       }
     },
     "number-is-nan": {
@@ -5152,6 +5939,12 @@
         "p-limit": "^1.1.0"
       }
     },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
@@ -5276,6 +6069,15 @@
       "dev": true,
       "requires": {
         "find-up": "^2.1.0"
+      }
+    },
+    "please-upgrade-node": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz",
+      "integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
       }
     },
     "pluralize": {
@@ -6082,6 +6884,12 @@
       "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
       "dev": true
     },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
+    },
     "send": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
@@ -6412,6 +7220,12 @@
       "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
       "dev": true
     },
+    "staged-git-files": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.1.tgz",
+      "integrity": "sha512-H89UNKr1rQJvI1c/PIR3kiAMBV23yvR7LItZiV74HWZwzt7f3YHuujJ9nJZlt58WlFox7XQsOahexwk7nTe69A==",
+      "dev": true
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -6465,6 +7279,12 @@
         }
       }
     },
+    "string-argv": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
+      "integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY=",
+      "dev": true
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -6491,6 +7311,17 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "stringify-object": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
+      "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "^2.0.1",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
       }
     },
     "strip-ansi": {
@@ -6523,6 +7354,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
       "dev": true
     },
     "strip-json-comments": {
@@ -6578,6 +7415,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "dev": true
     },
     "symbol-tree": {
       "version": "3.2.2",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2808,12 +2808,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2833,7 +2835,8 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -2981,6 +2984,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,7 +2,7 @@
   "name": "tournament-buzz-backend",
   "version": "1.0.0",
   "description": "Backend for TournamentBuzz Junior Design Team 8107",
-  "main": "app.js",
+  "main": "server.js",
   "scripts": {
     "dev": "node server.js",
     "test": "jest",

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,10 @@
   "main": "server.js",
   "scripts": {
     "dev": "node server.js",
-    "test": "jest",
+    "lint": "prettier --write \"**/*.js\" & eslint \"**/*.js\"",
+    "eslint": "eslint \"**/*.js\"",
+    "prettier": "prettier --write \"**/*.js\"",
+    "test": "jest & eslint \"**/*.js\"",
     "precommit": "lint-staged"
   },
   "lint-staged": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,15 @@
   "main": "app.js",
   "scripts": {
     "dev": "node server.js",
-    "test": "jest"
+    "test": "jest",
+    "precommit": "lint-staged"
+  },
+  "lint-staged": {
+    "**/*.js": [
+      "prettier --write",
+      "eslint",
+      "git add"
+    ]
   },
   "repository": {
     "type": "git",
@@ -29,7 +37,9 @@
     "eslint": "^5.5.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-promise": "^4.0.1",
+    "husky": "^0.14.3",
     "jest": "^23.5.0",
+    "lint-staged": "^7.2.2",
     "prettier": "^1.14.2",
     "supertest": "^3.3.0"
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,7 +27,10 @@
   },
   "devDependencies": {
     "eslint": "^5.5.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-promise": "^4.0.1",
     "jest": "^23.5.0",
+    "prettier": "^1.14.2",
     "supertest": "^3.3.0"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,7 +1,9 @@
-const config = require('./config');
-const app = require('./app');
+"use strict";
+
+const config = require("./config");
+const app = require("./app");
 
 const port = config.serverConfig.port;
 app.listen(port, () => {
-    console.log('Server running at port ' + port);
+  console.log("Server running at port " + port);
 });


### PR DESCRIPTION
I've included an ESLint config with a few plugins. It builds on the recommended configs with errors for simple/obvious problems and warnings for some of the more opinionated things.

The reason we didn't use the same eslint react config is because the frontend and backend are practically two separate projects. The eslint react config has rules and plugins tailored for react, and no rules tailored to serverside node.

Prettier is an autoformatter that I decided would be better to use than eslint's configuration rules. ESLint is impractical to actually use for style purposes. It does everything for you and only manages style. It is a bit opinionated but it has a few config options (quote style, indent size, etc).

This will require 0 changes to the current work flow. Both eslint and prettier are set to run automatically before each commit on just the files that you change. Prettier will rewrite all your files for you, while eslint will make sure you aren't committing any errors (warnings will pass).